### PR TITLE
Name thread & add check for device_id presence in last_check_devices list  

### DIFF
--- a/usbmonitor/__platform_specific_detectors/_linux_usb_detector.py
+++ b/usbmonitor/__platform_specific_detectors/_linux_usb_detector.py
@@ -72,7 +72,7 @@ class _LinuxUSBDetector(_USBDetectorBase):
                     device_info = self.__generate_tuple_attributes_from_string(device_info=device_info)
                     on_connect(device_id, device_info)
                     self.last_check_devices = self.get_available_devices()
-                elif action == "remove" and on_disconnect is not None:
+                elif action == "remove" and on_disconnect is not None and device_id in self.last_check_devices:
                     device_info = self.last_check_devices[device_id].copy()
                     on_disconnect(device_id, device_info)
                     self.last_check_devices = self.get_available_devices()

--- a/usbmonitor/__platform_specific_detectors/_linux_usb_detector.py
+++ b/usbmonitor/__platform_specific_detectors/_linux_usb_detector.py
@@ -81,7 +81,7 @@ class _LinuxUSBDetector(_USBDetectorBase):
             self.monitor = pyudev.Monitor.from_netlink(self.context)
             self.monitor.filter_by(subsystem='usb')
 
-        self._thread = pyudev.MonitorObserver(self.monitor, callback=__handle_device_event)
+        self._thread = pyudev.MonitorObserver(self.monitor, name="USB Monitor", callback=__handle_device_event)
 
         # Start the observer thread
         self._thread.start()

--- a/usbmonitor/__platform_specific_detectors/_usb_detector_base.py
+++ b/usbmonitor/__platform_specific_detectors/_usb_detector_base.py
@@ -125,7 +125,7 @@ class _USBDetectorBase(ABC):
                 USB devices. Defaults to 0.5 seconds.
         """
         assert self._thread is None, "The USB monitor is already running"
-        self._thread = threading.Thread(target=self._monitor_changes,
+        self._thread = threading.Thread(name="USB Monitor", target=self._monitor_changes,
                                         args=(on_connect, on_disconnect, check_every_seconds),
                                         daemon=True)
         self._thread.start()


### PR DESCRIPTION
After running in an issue on my Linux machine, I figured naming the thread might be useful for other people wondering what's happening with their application, but that is not the reason for the PR. 

The real problem is that upon disconnection of a device, `__handle_device_event()` will try the device_id index in the `last_check_devices` list. Problem is that somehow, for unknown reasons to me, the device_id is not present in the list. This causes the monitoring thread to crash.

This PR simply adds a check for the `device_id` presence inside the `last_check_devices` list before accessing the list. If not present, simply skip it. This avoids the crash and doesn't seem to affect functionality.

This fixes issue #2 