### PR TITLE
Fix deprecation warning

### DIFF
--- a/usbmonitor/__platform_specific_detectors/_linux_usb_detector.py
+++ b/usbmonitor/__platform_specific_detectors/_linux_usb_detector.py
@@ -32,11 +32,11 @@ class _LinuxUSBDetector(_USBDetectorBase):
         :return: dict[str, dict[str, str]]. The key is the device ID, the value is a dictionary of the device's
                 information.
         """
-        usb_devices = [device for device in self.context.list_devices(subsystem='usb') if ID_VENDOR_ID in device]
+        usb_devices = [device for device in self.context.list_devices(subsystem='usb') if ID_VENDOR_ID in device.properties]
         devices_info = {}
         for device in usb_devices:
-            device_id = device[DEVNAME]
-            device_info = {attr: device.get(attr, "") for attr in DEVICE_ATTRIBUTES}
+            device_id = device.properties[DEVNAME]
+            device_info = {attr: device.properties.get(attr, "") for attr in DEVICE_ATTRIBUTES}
             device_info = self.__generate_tuple_attributes_from_string(device_info=device_info)
             devices_info[device_id] = device_info
 
@@ -65,10 +65,10 @@ class _LinuxUSBDetector(_USBDetectorBase):
 
         def __handle_device_event(device):
             action = device.action
-            if device.get(DEVTYPE) == 'usb_device':
-                device_id = device[DEVNAME]
+            if device.properties.get(DEVTYPE) == 'usb_device':
+                device_id = device.properties[DEVNAME]
                 if action == "add" and on_connect is not None:
-                    device_info = {attr: device.get(attr, "") for attr in DEVICE_ATTRIBUTES}
+                    device_info = {attr: device.properties.get(attr, "") for attr in DEVICE_ATTRIBUTES}
                     device_info = self.__generate_tuple_attributes_from_string(device_info=device_info)
                     on_connect(device_id, device_info)
                     self.last_check_devices = self.get_available_devices()


### PR DESCRIPTION
I am getting deprecationWarning from _collections_abc

```
<frozen _collections_abc>:813: 29 warnings
  <frozen _collections_abc>:813: DeprecationWarning: Will be removed in 1.0. Access properties with Device.properties.

.venv/lib/python3.12/site-packages/usbmonitor/__platform_specific_detectors/_linux_usb_detector.py:38: 13 warnings
  /home/rhagelin.creatorctek.local/git/work/production-flash-station-snap/.venv/lib/python3.12/site-packages/usbmonitor/__platform_specific_detectors/_linux_usb_detector.py:38: DeprecationWarning: Will be removed in 1.0. Access properties with Device.properties.
    device_id = device[DEVNAME]

<frozen _collections_abc>:807: 143 warnings
  <frozen _collections_abc>:807: DeprecationWarning: Will be removed in 1.0. Access properties with Device.properties.
```